### PR TITLE
fix: remove `JavaScript` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ---
 
-It can take time to setup a new mac for JavaScript development.<br />
-MacRustle provides instructions to help with this process.
+It can take time to setup a new mac for development.<br />
+MacRustle provides super basic instructions to help with this process.
 
 ---
 


### PR DESCRIPTION
## Fixes

- Removes work `JavaScript` from the README. 

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
